### PR TITLE
feat: Create POST /api/animals endpoint for animal creation (resolve #107)

### DIFF
--- a/.claude/active_contexts
+++ b/.claude/active_contexts
@@ -13,3 +13,4 @@
 4. **Implementation Ready** - Context ready for implementation
 
 Last Updated: 2025-01-13 - Context #71: Single Farm MVP Design
+https://github.com/mojisejr/jaothui-id-e/issues/119

--- a/src/app/api/animals/route.ts
+++ b/src/app/api/animals/route.ts
@@ -1,0 +1,248 @@
+/**
+ * Animal Management API Endpoints - Jaothui ID-Trace System
+ *
+ * This file provides REST API endpoints for animal management operations.
+ * Follows existing codebase patterns and implements farm isolation security.
+ *
+ * Features:
+ * - POST /api/animals - Create new animal record
+ * - Session-based authentication using better-auth
+ * - Farm membership verification for security
+ * - Zod schema validation for input data
+ * - Comprehensive error handling with Thai messages
+ * - Duplicate tagId detection per farm
+ * - Farm isolation (users can only create animals in their own farm)
+ *
+ * @framework Next.js 14 App Router
+ * @authentication better-auth v1.3.34
+ * @database PostgreSQL via Prisma ORM
+ * @validation Zod schema
+ * @language TypeScript (strict mode)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/lib/auth";
+import { headers } from "next/headers";
+import { prisma } from "@/lib/prisma";
+import { animalSchema } from "@/lib/validations/animal";
+import { Prisma } from "@prisma/client";
+import { ZodError } from "zod";
+
+/**
+ * Required Next.js configuration for API routes
+ * Based on existing auth route pattern
+ */
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+/**
+ * POST /api/animals - Create New Animal
+ *
+ * Creates a new animal record for the authenticated user's farm.
+ * Implements comprehensive validation and security checks:
+ * 1. Verifies user authentication
+ * 2. Validates user has an active farm
+ * 3. Verifies farm membership
+ * 4. Validates input data with Zod schema
+ * 5. Creates animal with proper defaults
+ * 6. Handles duplicate tagId errors
+ *
+ * @returns { success: boolean, data?: { animal }, error?: object, message?: string, timestamp: string }
+ * @status 201 | 400 | 401 | 403 | 404 | 409 | 500
+ */
+export async function POST(request: NextRequest) {
+  try {
+    // Step 1: Authenticate user using existing codebase pattern
+    const session = await auth.api.getSession({ headers: await headers() });
+
+    if (!session?.user?.id) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "UNAUTHORIZED",
+            message: "ต้องเข้าสู่ระบบก่อน",
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 401 }
+      );
+    }
+
+    // Step 2: Parse request body
+    const body = await request.json();
+
+    // Step 3: Get user's farm (following existing farm API pattern)
+    const farm = await prisma.farm.findFirst({
+      where: { ownerId: session.user.id },
+    });
+
+    if (!farm) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FARM_NOT_FOUND",
+            message: "ไม่พบฟาร์มของคุณ กรุณาสร้างฟาร์มก่อน",
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 404 }
+      );
+    }
+
+    // Step 4: Verify user is farm member (security check)
+    const membership = await prisma.farmMember.findUnique({
+      where: {
+        farmId_userId: {
+          farmId: farm.id,
+          userId: session.user.id,
+        },
+      },
+    });
+
+    if (!membership) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "FORBIDDEN",
+            message: "คุณไม่มีสิทธิ์เข้าถึงฟาร์มนี้",
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 403 }
+      );
+    }
+
+    // Step 5: Auto-populate farmId from session (farm isolation)
+    const dataWithFarm = {
+      ...body,
+      farmId: farm.id,
+    };
+
+    // Step 6: Validate input with Zod schema (from Task 1.1)
+    const validatedData = animalSchema.parse(dataWithFarm);
+
+    // Step 7: Create animal in database via Prisma
+    // Status is auto-set to "ACTIVE" by schema default
+    // Timestamps are auto-managed by Prisma
+    const animal = await prisma.animal.create({
+      data: {
+        farmId: validatedData.farmId,
+        tagId: validatedData.tagId,
+        type: validatedData.type,
+        name: validatedData.name || null,
+        gender: validatedData.gender || "FEMALE",
+        color: validatedData.color || null,
+        birthDate: validatedData.birthDate ? new Date(validatedData.birthDate) : null,
+        weightKg: validatedData.weightKg || null,
+        heightCm: validatedData.heightCm || null,
+        motherTag: validatedData.motherTag || null,
+        fatherTag: validatedData.fatherTag || null,
+        genome: validatedData.genome || null,
+        // status defaults to ACTIVE via Prisma schema
+        // imageUrl defaults to null
+      },
+    });
+
+    // Step 8: Return success response with created animal
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          animal,
+        },
+        message: "บันทึกข้อมูลกระบือสำเร็จแล้ว",
+        timestamp: new Date().toISOString(),
+      },
+      { status: 201 }
+    );
+
+  } catch (error) {
+    // Handle Zod validation errors
+    if (error instanceof ZodError) {
+      const details = error.issues.map((err) => ({
+        field: err.path.join("."),
+        message: err.message,
+      }));
+
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "VALIDATION_ERROR",
+            message: "ข้อมูลไม่ถูกต้อง",
+            details,
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 400 }
+      );
+    }
+
+    // Handle Prisma database errors
+    if (error instanceof Prisma.PrismaClientKnownRequestError) {
+      // P2002: Unique constraint violation (duplicate tagId in farm)
+      if (error.code === "P2002") {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "DUPLICATE_TAG",
+              message: "หมายเลขแท็กนี้มีในระบบแล้ว",
+            },
+            timestamp: new Date().toISOString(),
+          },
+          { status: 409 }
+        );
+      }
+
+      // P2003: Foreign key constraint violation
+      if (error.code === "P2003") {
+        return NextResponse.json(
+          {
+            success: false,
+            error: {
+              code: "INVALID_REFERENCE",
+              message: "ข้อมูลอ้างอิงไม่ถูกต้อง",
+            },
+            timestamp: new Date().toISOString(),
+          },
+          { status: 400 }
+        );
+      }
+    }
+
+    // Handle JSON parsing errors
+    if (error instanceof SyntaxError) {
+      return NextResponse.json(
+        {
+          success: false,
+          error: {
+            code: "INVALID_JSON",
+            message: "รูปแบบข้อมูลไม่ถูกต้อง",
+          },
+          timestamp: new Date().toISOString(),
+        },
+        { status: 400 }
+      );
+    }
+
+    // Log unexpected errors for debugging
+    console.error("Animal POST error:", error);
+
+    // Return generic internal server error
+    return NextResponse.json(
+      {
+        success: false,
+        error: {
+          code: "INTERNAL_ERROR",
+          message: "เกิดข้อผิดพลาดในการบันทึก",
+        },
+        timestamp: new Date().toISOString(),
+      },
+      { status: 500 }
+    );
+  }
+}


### PR DESCRIPTION
## Summary

This PR implements the **POST /api/animals endpoint** for animal creation in the Jaothui ID-Trace system.

- **Resolves**: #107 - Create POST /api/animals Endpoint for Animal Creation
- **Context**: #79 - Animal Creation System
- **Feature Branch**: `feature/task-107-post-animals-endpoint`

## 📋 Implementation Overview

Creates a secure API endpoint that handles animal registration with comprehensive validation and farm isolation. Users can add new animals to their farm with complete information tracking.

## ✨ Features Implemented

### Core Functionality
- ✅ POST endpoint at `src/app/api/animals/route.ts`
- ✅ Session-based authentication via better-auth
- ✅ Farm membership verification for security
- ✅ Auto-population of farmId from user session
- ✅ Automatic status set to "ACTIVE"

### Input Validation
- ✅ Comprehensive Zod schema validation (from Task 1.1)
- ✅ Required fields: tagId, type
- ✅ Optional fields: name, gender, birthDate, color, weightKg, heightCm, motherTag, fatherTag, genome
- ✅ Proper error messages in Thai language

### Security & Data Integrity
- ✅ Authentication check: Verifies session exists
- ✅ Farm ownership: Only allows users to create in their own farm
- ✅ Farm membership: Verifies user is a farm member
- ✅ Unique constraint: Database enforces [farmId, tagId] uniqueness per farm
- ✅ Timestamp auto-management by Prisma

### Error Handling
- ✅ 201: Success - "บันทึกข้อมูลกระบือสำเร็จแล้ว"
- ✅ 400: Validation errors with field details
- ✅ 401: Unauthorized - "ต้องเข้าสู่ระบบก่อน"
- ✅ 403: Forbidden - "คุณไม่มีสิทธิ์เข้าถึงฟาร์มนี้"
- ✅ 404: Farm not found - "ไม่พบฟาร์มของคุณ"
- ✅ 409: Duplicate tagId - "หมายเลขแท็กนี้มีในระบบแล้ว"
- ✅ 500: Internal error - "เกิดข้อผิดพลาดในการบันทึก"

## 📁 Files Changed

```
.claude/active_contexts       | +1 
src/app/api/animals/route.ts  | +248 (new file)
```

## ✅ Validation Results

```bash
Build:      ✓ Compiled successfully (100% PASS)
Lint:       ✓ No errors (100% PASS)
Type Check: ✓ No type errors (100% PASS)
Tests:      ✓ 9/9 tests passed (100% PASS)
```

All validations executed and passed:
- `npm run build` - Next.js production build successful
- `npm run lint` - ESLint validation clean
- `npx tsc --noEmit` - TypeScript type checking passed
- `npm test` - Jest test suite passed

## 🔄 Test Plan

- [ ] Manual API testing with valid animal data
- [ ] Validation testing with invalid inputs
- [ ] Farm isolation testing (user can only create in own farm)
- [ ] Duplicate tagId rejection testing
- [ ] Error response validation (all status codes)
- [ ] Integration with CreateAnimalForm component (Task 1.2)

## 📚 Related Issues

- **Context**: #79 - Animal Creation System
- **Depends On**: Task 1.1 - Zod validation schema ✅
- **Required By**: Task 1.2 - CreateAnimalForm component
- **Next**: Task 1.4 - Additional animal endpoints

## 🔗 API Documentation

**Request Example**:
```json
POST /api/animals
{
  "farmId": "uuid",
  "tagId": "001",
  "type": "WATER_BUFFALO",
  "name": "นาเดีย",
  "gender": "FEMALE",
  "color": "ดำ",
  "birthDate": "2562-03-15",
  "weightKg": 450.5,
  "heightCm": 145,
  "motherTag": "M001",
  "fatherTag": "F001"
}
```

**Success Response (201)**:
```json
{
  "success": true,
  "data": { "animal": { ... } },
  "message": "บันทึกข้อมูลกระบือสำเร็จแล้ว",
  "timestamp": "2025-11-15T12:00:00Z"
}
```

## 📝 Implementation Details

### Code Quality
- Follows existing farm API pattern (`src/app/api/farm/route.ts`)
- Consistent with better-auth session handling
- Proper TypeScript types and error handling
- Comprehensive JSDoc comments for maintainability

### Security Measures
- Zero-trust authentication (requires valid session)
- Farm isolation (farmId auto-populated from session, not user input)
- Input validation via Zod schema
- Database constraint enforcement
- Comprehensive error handling

### Database Integration
- Uses Prisma ORM for type-safe queries
- Leverages database unique constraints
- Auto-managed timestamps
- Proper foreign key relationships

---

🤖 **Generated with Claude Code**  
Co-Authored-By: Claude <noreply@anthropic.com>