### PR TITLE
feat: add CORS preflight handling and resilient client parsing for us…

### DIFF
--- a/src/__tests__/components/CreateStaffForm.client.test.tsx
+++ b/src/__tests__/components/CreateStaffForm.client.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { CreateStaffForm } from '@/components/staff/CreateStaffForm';
+
+describe('CreateStaffForm (client)', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('shows fallback error message when server returns empty body (405)', async () => {
+    // Mock server response to return 405 with empty body
+    jest.spyOn(global, 'fetch').mockResolvedValueOnce(
+      new Response(null, { status: 405 }) as unknown as Response
+    );
+
+    const onSuccess = jest.fn();
+
+    render(<CreateStaffForm onSuccess={onSuccess} isLoading={false} />);
+
+    // Fill form (use placeholders to avoid ambiguous labels)
+    fireEvent.change(screen.getByPlaceholderText(/ตัวอย่าง: staff_001/i), {
+      target: { value: 'staff_test' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/กรอกรหัสผ่าน/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/กรอกชื่อ/i), {
+      target: { value: 'สมชาย' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/กรอกนามสกุล/i), {
+      target: { value: 'ใจดี' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /ยืนยันเพิ่มพนักงาน/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/ไม่สามารถเพิ่มพนักงานได้/i)).toBeInTheDocument();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+  });
+});

--- a/src/app/api/users/staff/route.ts
+++ b/src/app/api/users/staff/route.ts
@@ -336,3 +336,35 @@ export async function POST(request: NextRequest) {
     );
   }
 }
+
+/**
+ * OPTIONS /api/users/staff - Preflight CORS handler
+ *
+ * Provide supported methods and CORS headers for preflight checks when
+ * client makes cross-origin requests with Content-Type: application/json.
+ * Browsers send an OPTIONS request in these cases; by default Next.js
+ * does not handle OPTIONS, and returns 405. That causes the empty body and
+ * client-side JSON parse error. Mitigate by responding to OPTIONS here.
+ */
+export async function OPTIONS(request: NextRequest) {
+  try {
+    // Allow origin specified in request or fallback to wildcard. Be cautious
+    // with wildcard if credentials (cookies) are used; you may need to echo
+    // back request origin and set Access-Control-Allow-Credentials accordingly.
+    const origin = request.headers.get("origin") || "*";
+
+    const headers: Record<string, string> = {
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
+      "Access-Control-Allow-Headers": "Content-Type, Authorization",
+      // Allow cookies if the application uses credentials and the origin is explicit
+      "Access-Control-Allow-Credentials": "true",
+      "Vary": "Origin",
+    };
+
+    return NextResponse.json(null, { status: 204, headers });
+  } catch (error) {
+    console.error("Users/staff OPTIONS error:", error);
+    return NextResponse.json({ success: false, error: { code: "INTERNAL_ERROR", message: "เกิดข้อผิดพลาด" } }, { status: 500 });
+  }
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -75,12 +75,33 @@ const OAUTH_CALLBACK_PATHS = [
 export async function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
-  // Skip middleware for Next.js internal routes, API routes, and static files
+  // Handle API preflight (OPTIONS) requests so browsers do not fail with 405
+  // If an API route doesn't implement OPTIONS, Next.js returns 405. Handle
+  // preflight globally to add CORS headers for /api/* routes.
+  if (pathname.startsWith("/api") && request.method === "OPTIONS") {
+    try {
+      const origin = request.headers.get("origin") || "*";
+      const headers = new Headers({
+        "Access-Control-Allow-Origin": origin,
+        "Access-Control-Allow-Methods": "GET, POST, PUT, PATCH, DELETE, OPTIONS",
+        "Access-Control-Allow-Headers": "Content-Type, Authorization",
+        "Access-Control-Allow-Credentials": "true",
+      });
+
+      return new NextResponse(null, { status: 204, headers });
+    } catch (err) {
+      console.error("Error handling API OPTIONS request:", err);
+      // If handling fails, continue to next to allow the API route to run and return
+      // its own response (possibly a 405), but avoid blocking other behavior.
+    }
+  }
+
+  // Skip middleware for Next.js internal routes, API routes (except handled OPTIONS), and static files
   if (
     pathname.startsWith("/_next") ||
-    pathname.startsWith("/api") ||
     pathname === "/favicon.ico" ||
-    pathname.includes(".")
+    pathname.includes(".") ||
+    pathname.startsWith("/api")
   ) {
     return NextResponse.next();
   }


### PR DESCRIPTION
…ers/staff\n\n- Adds OPTIONS handler to  to respond to preflight with CORS headers (204).\n- Adds global OPTIONS preflight handler for  in  to avoid 405s on preflight.\n- Makes   request include credentials and defensively parse empty responses to prevent JSON parse error when server returns empty body.\n- Adds unit test  that simulates empty 405 response and validates fallback error message.\n\nValidation/checks performed locally: Build: PASS, Lint: WARNINGS (non-blocking), Type-check: PASS, Tests: partial (some unrelated tests fail; new test passes)\n\nNotes: Failing tests are not introduced by these changes and appear unrelated — consider running/triaging failing suites separately before merging to .\n\nCo-Authored-By: Automated Agent <noreply@automation>