### PR TITLE
feat: Implement role-based menu filtering for farm members (resolve #0) #207 [Main]

### DIFF
--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -46,7 +46,7 @@ import { useSession, signOut } from "@/lib/auth-client";
 // Profile Components Integration
 import TopNavigation from "@/components/profile/TopNavigation";
 import { ProfileCard, Farm } from "@/components/profile/ProfileCard";
-import MenuGrid, { defaultMenuItems } from "@/components/profile/MenuGrid";
+import MenuGrid, { defaultMenuItems, type UserRole } from "@/components/profile/MenuGrid";
 import { GhostLogoutButton } from "@/components/profile/GhostLogoutButton";
 
 export default function ProfilePage() {
@@ -57,6 +57,7 @@ export default function ProfilePage() {
   const [farm, setFarm] = React.useState<Farm | null>(null);
   const [isLoadingFarm, setIsLoadingFarm] = React.useState(true);
   const [farmError, setFarmError] = React.useState<string | null>(null);
+  const [userRole, setUserRole] = React.useState<UserRole>('OWNER');
 
   /**
    * Redirect to login if not authenticated
@@ -133,6 +134,17 @@ export default function ProfilePage() {
   const handleFarmUpdate = (updatedFarm: Farm) => {
     setFarm(updatedFarm);
   };
+
+  /**
+   * Determine user role based on farm ownership
+   */
+  React.useEffect(() => {
+    if (session?.user?.id && farm) {
+      // If user owns the farm, they are OWNER, otherwise MEMBER
+      const role: UserRole = farm.ownerId === session.user.id ? 'OWNER' : 'MEMBER';
+      setUserRole(role);
+    }
+  }, [session, farm]);
 
   /**
    * Loading state while checking authentication
@@ -268,6 +280,7 @@ export default function ProfilePage() {
           <div className="flex justify-center">
             <MenuGrid
               menuItems={defaultMenuItems}
+              userRole={userRole}
               className="w-full max-w-2xl"
             />
           </div>

--- a/src/components/profile/MenuGrid.tsx
+++ b/src/components/profile/MenuGrid.tsx
@@ -45,7 +45,14 @@ export interface MenuItem {
   href: string;
   /** Accessibility description for screen readers */
   description?: string;
+  /** User roles that can access this menu item */
+  allowedRoles?: UserRole[];
 }
+
+/**
+ * User role type for menu filtering
+ */
+export type UserRole = 'OWNER' | 'MEMBER';
 
 /**
  * MenuGridProps interface
@@ -54,6 +61,8 @@ export interface MenuItem {
 export interface MenuGridProps {
   /** Array of menu items to display in the grid */
   menuItems: MenuItem[];
+  /** User role for filtering menu items */
+  userRole?: UserRole;
   /** Optional additional CSS classes */
   className?: string;
 }
@@ -86,6 +95,7 @@ export const defaultMenuItems: MenuItem[] = [
     helpText: "Add Staff",
     href: "/staff/create",
     description: "เพิ่มพนักงานในฟาร์ม",
+    allowedRoles: ['OWNER'], // Only farm owners can access staff management
   },
   {
     id: "feeding",
@@ -135,10 +145,21 @@ export const defaultMenuItems: MenuItem[] = [
  * />
  * ```
  */
-export function MenuGrid({ 
-  menuItems = defaultMenuItems, 
-  className 
+export function MenuGrid({
+  menuItems = defaultMenuItems,
+  userRole = 'OWNER',
+  className
 }: MenuGridProps): React.ReactElement {
+  // Filter menu items based on user role
+  const filteredMenuItems = menuItems.filter((item) => {
+    // If no allowedRoles specified, allow all users
+    if (!item.allowedRoles || item.allowedRoles.length === 0) {
+      return true;
+    }
+    // Only show items that match user's role
+    return item.allowedRoles.includes(userRole);
+  });
+
   return (
     <nav
       className={cn(
@@ -153,7 +174,7 @@ export function MenuGrid({
         role="group"
         aria-label="กลุ่มเมนูหลัก"
       >
-        {menuItems.map((item) => (
+        {filteredMenuItems.map((item) => (
           <Link
             key={item.id}
             href={item.href}


### PR DESCRIPTION
This pull request introduces role-based access control for the profile menu, ensuring that certain menu items are only visible to users with the appropriate role (e.g., farm owners vs. members). The main changes include defining a `UserRole` type, updating menu items to specify allowed roles, and filtering the displayed menu items based on the current user's role.

**Role-based menu filtering:**

* Added a new `UserRole` type (`'OWNER' | 'MEMBER'`) and an optional `allowedRoles` property to the `MenuItem` interface in `MenuGrid.tsx` for specifying which user roles can access each menu item.
* Updated `defaultMenuItems` to restrict the "Add Staff" menu item to only users with the `'OWNER'` role.
* Modified the `MenuGrid` component to accept a `userRole` prop and filter menu items based on the user's role before rendering. [[1]](diffhunk://#diff-d5c6a80acc4746f08342482049367fac0eff04aae371ca3da0acb3c903e8844fR150-R162) [[2]](diffhunk://#diff-d5c6a80acc4746f08342482049367fac0eff04aae371ca3da0acb3c903e8844fL156-R177)

**Profile page integration:**

* In `ProfilePage`, determined the user's role (`'OWNER'` or `'MEMBER'`) based on farm ownership and passed it to `MenuGrid` to control menu visibility. [[1]](diffhunk://#diff-5a4d3fe72cb3d22761491f67ae6eeac245f42e9d6aa1089628093df3c7a2f280L49-R49) [[2]](diffhunk://#diff-5a4d3fe72cb3d22761491f67ae6eeac245f42e9d6aa1089628093df3c7a2f280R60) [[3]](diffhunk://#diff-5a4d3fe72cb3d22761491f67ae6eeac245f42e9d6aa1089628093df3c7a2f280R138-R148) [[4]](diffhunk://#diff-5a4d3fe72cb3d22761491f67ae6eeac245f42e9d6aa1089628093df3c7a2f280R283)